### PR TITLE
Rewrite all opts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,22 @@ version = "0.3.0"
 
 [dependencies]
 cfg-if = "0.1.2"
-errno = "0.2.3"
+errno  = "0.2.3"
 libc = "0.2"
-log = "0.3"
+log  = "0.3"
 sendfd = "0.1.0"
 thread-scoped = "1"
 time = "0.1"
-getopts = "0.2.15"
+
+#rust-mount dependencie
+getopts = { version = "0.2.15", optional = true }
 
 [dev-dependencies]
 env_logger = "0.3"
 
 [features]
-rust-mount = []
+default = []
+rust-mount = ["getopts"]
 
 [lib]
 name = "fuse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,31 +1,33 @@
 [package]
-name = "fuse"
-version = "0.3.0"
 authors = ["Andreas Neuhaus <zargony@zargony.com>", "Eric Delanghe <delanghe.eric.dev@gmail.com>"]
+build = "build.rs"
+categories = ["api-bindings", "filesystem"]
 description = "Rust library for filesystems in userspace (FUSE)"
 documentation = "https://docs.rs/fuse"
 homepage = "https://github.com/zargony/rust-fuse"
-repository = "https://github.com/zargony/rust-fuse"
-readme = "README.md"
 keywords = ["fuse", "filesystem", "system", "bindings"]
-categories = ["api-bindings", "filesystem"]
 license = "MIT"
-build = "build.rs"
+name = "fuse"
+readme = "README.md"
+repository = "https://github.com/zargony/rust-fuse"
+version = "0.3.0"
 
 [dependencies]
+cfg-if = "0.1.2"
 errno = "0.2.3"
 libc = "0.2"
 log = "0.3"
-time = "0.1"
-thread-scoped = "1"
 sendfd = "0.1.0"
+thread-scoped = "1"
+time = "0.1"
+getopts = "0.2.15"
 
 [dev-dependencies]
 env_logger = "0.3"
 
+[features]
+rust-mount = []
+
 [lib]
 name = "fuse"
 path = "src/lib.rs"
-
-[features]
-rust-mount = []

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -7,7 +7,7 @@ use std::ffi::{CString, CStr, OsStr};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{PathBuf, Path};
 use libc::{self, c_int, c_void, size_t};
-use fuse::fuse_args;
+use fuse_opts::fuse_args;
 use reply::ReplySender;
 
 /// Helper function to provide options as a fuse_args struct

--- a/src/fuse_opts.rs
+++ b/src/fuse_opts.rs
@@ -76,6 +76,22 @@ cfg_if! {
             }
         }
 
+        //
+        // fn get_get(type: ident, tab: FuseOpts) -> Option<ident::value>
+        // 
+        macro_rules! get_opt {
+            ($type: ident, $tab: expr) => {{
+                let mut res = None;
+                for i in $tab.opts.iter().rev() {
+                    if let MetaFuseOpt::$type(v) = *i {
+                        res = Some(v);
+                        break ;
+                    }
+                }
+                res
+            }}
+        }
+
         pub struct FuseOpts {
             pub opts: Vec<MetaFuseOpt>,
         }
@@ -91,6 +107,10 @@ cfg_if! {
                 FuseOpts {
                     opts: Vec::new(),
                 }
+            }
+
+            pub fn add_opt(&mut self, opt: MetaFuseOpt) {
+                self.opts.push(opt);
             }
 
             pub fn fuse_opt_parse(&mut self, args: &fuse_args) {

--- a/src/fuse_opts.rs
+++ b/src/fuse_opts.rs
@@ -1,0 +1,114 @@
+
+
+//
+// FUSE arguments (see fuse_opt.h for details)
+//
+
+use libc::{c_char, c_int};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct fuse_args {
+    pub argc: c_int,
+    pub argv: *const *const c_char,
+    pub allocated: c_int,
+}
+
+cfg_if! {
+    if #[cfg(feature="rust-mount")] {
+
+        use libc::{mode_t, uid_t, gid_t};
+        use getopts::Options;
+        use std::str::FromStr;
+        use std::ffi::CStr;
+        use std::slice;
+
+        #[derive(Copy, Clone, Debug, PartialEq)]
+        pub struct ParseError;
+
+        pub enum MetaFuseOpt {
+            Uid(uid_t),
+            Gid(gid_t),
+            RootMode(mode_t),
+            AllowOther,
+            DefaultPermissions,
+            NonEmpty,
+            SubType(String),
+            #[cfg(target_os = "darwin")]
+            Volname(String), // osxfuse option
+        }
+
+        impl FromStr for MetaFuseOpt {
+            type Err = ParseError;
+
+            fn from_str(s :&str) -> Result<Self, Self::Err> {
+                let (a, b) = s.split_at(s.find("=").unwrap_or(s.len()));
+
+                match (a, String::from(b.trim_left_matches('='))) {
+                    ("user_id", val) => Ok(MetaFuseOpt::Uid(val.parse::<uid_t>().unwrap())),
+                    ("group_id", val) => Ok(MetaFuseOpt::Gid(val.parse::<gid_t>().unwrap())),
+                    ("rootmode", val) => Ok(MetaFuseOpt::RootMode(val.parse::<mode_t>().unwrap())),
+                    ("allow_other", _) => Ok(MetaFuseOpt::AllowOther),
+                    ("default_permissions", _) => Ok(MetaFuseOpt::DefaultPermissions),
+                    ("nonempty", _) => Ok(MetaFuseOpt::NonEmpty),
+                    ("subtype", val) => Ok(MetaFuseOpt::SubType(val.clone())),
+                    #[cfg(target_os = "darwin")]
+                    ("volname", val) => Ok(MetaFuseOpt::Volname(val.clone())),
+                    _ => Err(ParseError),
+                }
+            }
+        }
+
+        impl ToString for MetaFuseOpt {
+            fn to_string(&self) -> String {
+                match *self {
+
+                    MetaFuseOpt::Uid(val) => format!("user_id={}", val),
+                    MetaFuseOpt::Gid(val) => format!("group_id={}", val),
+                    MetaFuseOpt::RootMode(val) => format!("rootmode={}", val),
+                    MetaFuseOpt::AllowOther => String::from("allow_other"),
+                    MetaFuseOpt::DefaultPermissions => String::from("default_permissions"),
+                    MetaFuseOpt::NonEmpty => String::from("nonempty"),
+                    MetaFuseOpt::SubType(ref val) => format!("subtype={}", val),
+                    #[cfg(target_os = "darwin")]
+                    MetaFuseOpt::Volname(ref val) => format!("volname={}", val),
+                }
+            }
+        }
+
+        pub struct FuseOpts {
+            pub opts: Vec<MetaFuseOpt>,
+        }
+
+        impl ToString for FuseOpts {
+            fn to_string(&self) -> String {
+                self.opts.iter().map(|x| x.to_string()).collect::<Vec<String>>().join(",")
+            }
+        }
+
+        impl FuseOpts {
+            pub fn new() -> FuseOpts {
+                FuseOpts {
+                    opts: Vec::new(),
+                }
+            }
+
+            pub fn fuse_opt_parse(&mut self, args: &fuse_args) {
+                let mut opts = Options::new();
+                opts.optmulti("o", "option", "", "FILE");
+
+                let argv: Vec<&str> = unsafe {
+                    let paths: &[*const _] = slice::from_raw_parts(args.argv, args.argc as usize);
+                    paths.iter().map(
+                        |cs| CStr::from_ptr(*cs).to_str().expect("Error convert argv")
+                        ).collect()
+                };
+
+                let matches = opts.parse(argv.iter()).unwrap();
+                let optss: _ = matches.opt_strs("o");
+                let opts = optss.iter().map(|x| x.split(",").collect()).collect::<Vec<Vec<_>>>().concat();
+                self.opts.extend(opts.iter().map(|x| MetaFuseOpt::from_str(x.trim()).unwrap()).collect::<Vec<MetaFuseOpt>>());
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,15 +10,20 @@
 #![warn(missing_docs, bad_style, unused, unused_extern_crates, unused_import_braces, unused_qualifications, missing_debug_implementations)]
 
 extern crate libc;
-#[cfg(feature="rust-mount")]
-extern crate errno;
-#[cfg(feature="rust-mount")]
-extern crate sendfd;
 
 #[macro_use]
 extern crate log;
 extern crate time;
 extern crate thread_scoped;
+#[macro_use]
+extern crate cfg_if;
+cfg_if! {
+    if #[cfg(feature="rust-mount")] {
+        extern crate errno;
+        extern crate sendfd;
+        extern crate getopts;
+    }
+}
 
 use std::convert::AsRef;
 use std::io;
@@ -43,6 +48,7 @@ mod fuse;
 mod reply;
 mod request;
 mod session;
+mod fuse_opts;
 
 /// File types
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,13 +42,14 @@ pub use reply::ReplyXTimes;
 pub use request::Request;
 pub use session::{Session, BackgroundSession};
 
+#[macro_use]
+mod fuse_opts;
 mod argument;
 mod channel;
 mod fuse;
 mod reply;
 mod request;
 mod session;
-mod fuse_opts;
 
 /// File types
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]


### PR DESCRIPTION
Add fuse_opts.rs

With enum MetaFuseOpt, and struct FuseOpts

MetaFuseOpt are all availables options of libfuse
FuseOpts is a containers for this options

default rootmode is now 40755 instead of 40000
